### PR TITLE
Update Gem Dependencies for support of Ruby 2.1 and later

### DIFF
--- a/lib/metro/font.rb
+++ b/lib/metro/font.rb
@@ -58,7 +58,7 @@ module Metro
     end
 
     def self.create_gosu_font(window, name, size)
-      Gosu::Font.new window, name, size
+      Gosu::Font.new size, name: name
     end
 
     def self.fonts

--- a/lib/setup_handlers/reload_game_on_game_file_changes.rb
+++ b/lib/setup_handlers/reload_game_on_game_file_changes.rb
@@ -45,8 +45,9 @@ module Metro
       # Defines the listener that will watch the filepaths
       #
       def watch_filepaths(filepaths)
-        listener = Listen.to(*filepaths)
-        listener.change(&on_change)
+        listener = Listen.to(*filepaths) do |modified, added, removed|
+          on_change(modified, added, removed)
+        end
         listener.start
       end
 
@@ -54,8 +55,8 @@ module Metro
       # @return [Proc] the body of code to execute when a file change event has
       #   been received.
       #
-      def on_change
-        Proc.new { |modified,added,removed| reload_game_because_files_changed(modified + added + removed) }
+      def on_change(modified, added, removed)
+        reload_game_because_files_changed(modified + added + removed)
       end
 
       #

--- a/metro.gemspec
+++ b/metro.gemspec
@@ -24,20 +24,15 @@ Gem::Specification.new do |gem|
 
   gem.homepage      = Metro::WEBSITE
 
-  gem.add_dependency 'gosu', '~> 0.7'
+  gem.add_dependency 'gosu'
+  gem.add_dependency 'texplay', '~> 0.4.4.pre'
 
-  if RUBY_PLATFORM == "i386-mingw32"
-    gem.add_dependency 'texplay', '~> 0.4'
-  else
-    gem.add_dependency 'texplay', '~> 0.4.4.pre'
-  end
-
-  gem.add_dependency 'chipmunk', '~> 6.1.3.1'
-  gem.add_dependency 'tmx', '~> 0.1.2'
-  gem.add_dependency 'thor', '~> 0.19.1'
-  gem.add_dependency 'i18n', '~> 0.6.1'
-  gem.add_dependency 'activesupport', '~> 4.1.4'
-  gem.add_dependency 'listen', '~> 0.6.0'
+  gem.add_dependency 'chipmunk'
+  gem.add_dependency 'tmx'
+  gem.add_dependency 'thor'
+  gem.add_dependency 'i18n'
+  gem.add_dependency 'activesupport', '~> 4.2'
+  gem.add_dependency 'listen'
   gem.add_development_dependency 'rspec', '~> 2.11'
   gem.add_development_dependency 'rspec-its', '~> 1.0.1'
 


### PR DESCRIPTION
Hi,

The Gem dependencies were very tightly bound to many Gems that received updates in the past 2 years. It is good practice not to specify version the the gemspec, unless absolute necessary.
This is necessary for texplay. 0.4.4.pre is not only required for Windows development environments, but also for Ruby 2.1 and later on OSX.
The newer versions listen gem don’t offer giving Procs anymore, so this was slightly rewritten.
Gosu::Font has a different constructor now.

bye,
Dahie